### PR TITLE
Added OAuth support.

### DIFF
--- a/lib/hubspot/config.rb
+++ b/lib/hubspot/config.rb
@@ -1,9 +1,10 @@
 require 'logger'
+require 'hubspot/connection'
 
 module Hubspot
   class Config
 
-    CONFIG_KEYS = [:hapikey, :base_url, :portal_id, :logger]
+    CONFIG_KEYS = [:hapikey, :base_url, :portal_id, :logger, :access_token]
     DEFAULT_LOGGER = Logger.new('/dev/null')
 
     class << self
@@ -14,7 +15,14 @@ module Hubspot
         @hapikey = config["hapikey"]
         @base_url = config["base_url"] || "https://api.hubapi.com"
         @portal_id = config["portal_id"]
-        @logger = config['logger'] || DEFAULT_LOGGER
+        @logger = config["logger"] || DEFAULT_LOGGER
+        @access_token = config["access_token"]
+        unless access_token.present? ^ hapikey.present?
+          Hubspot::ConfigurationError.new("You must provide either an access_token or an hapikey")
+        end
+        if access_token.present?
+          Hubspot::Connection.headers("Authorization" => "Bearer #{access_token}")
+        end
         self
       end
 
@@ -23,6 +31,8 @@ module Hubspot
         @base_url = "https://api.hubapi.com"
         @portal_id = nil
         @logger = DEFAULT_LOGGER
+        @access_token = nil
+        Hubspot::Connection.headers({})
       end
 
       def ensure!(*params)

--- a/lib/hubspot/connection.rb
+++ b/lib/hubspot/connection.rb
@@ -45,7 +45,11 @@ module Hubspot
       end
 
       def generate_url(path, params={}, options={})
-        Hubspot::Config.ensure! :hapikey
+        if Hubspot::Config.access_token.present?
+          options[:hapikey] = false
+        else
+          Hubspot::Config.ensure! :hapikey
+        end
         path = path.clone
         params = params.clone
         base_url = options[:base_url] || Hubspot::Config.base_url


### PR DESCRIPTION
- This commit lets the user pass an "access_token" to Hubspot.configure. At that point,
if an access token is passed, we set default headers on the Connection class, and this supports OAuth.

- I added a check in the get_url method which will not set an API key if an access token is present. This is required. Otherwise, Hubspot will fail the request, thinking that the api key was the intended auth method, but that the key was blank.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hinthealth/hubspot-ruby/1)
<!-- Reviewable:end -->
