### PR TITLE
Added an OAuth class for refreshing/creating.

### DIFF
--- a/lib/hubspot-ruby.rb
+++ b/lib/hubspot-ruby.rb
@@ -18,6 +18,7 @@ require 'hubspot/deal_pipeline'
 require 'hubspot/deal_properties'
 require 'hubspot/owner'
 require 'hubspot/engagement'
+require 'hubspot/oauth'
 
 module Hubspot
   def self.configure(config={})

--- a/lib/hubspot/config.rb
+++ b/lib/hubspot/config.rb
@@ -4,7 +4,10 @@ require 'hubspot/connection'
 module Hubspot
   class Config
 
-    CONFIG_KEYS = [:hapikey, :base_url, :portal_id, :logger, :access_token]
+    CONFIG_KEYS = [
+      :hapikey, :base_url, :portal_id, :logger, :access_token, :client_id,
+      :client_secret, :redirect_uri
+    ]
     DEFAULT_LOGGER = Logger.new('/dev/null')
 
     class << self
@@ -17,6 +20,10 @@ module Hubspot
         @portal_id = config["portal_id"]
         @logger = config["logger"] || DEFAULT_LOGGER
         @access_token = config["access_token"]
+        @client_id = config["client_id"] if config["client_id"].present?
+        @client_secret = config["client_secret"] if config["client_secret"].present?
+        @redirect_uri = config["redirect_uri"] if config["redirect_uri"].present?
+
         unless access_token.present? ^ hapikey.present?
           Hubspot::ConfigurationError.new("You must provide either an access_token or an hapikey")
         end

--- a/lib/hubspot/oauth.rb
+++ b/lib/hubspot/oauth.rb
@@ -1,0 +1,46 @@
+require 'httparty'
+module Hubspot
+  class OAuth < Connection
+    include HTTParty
+    DEFAULT_OAUTH_HEADERS = {"Content-Type" => "application/x-www-form-urlencoded;charset=utf-8"}
+    class << self
+      def refresh(params)
+        params.stringify_keys!
+        no_parse = params.delete("no_parse") { false }
+        body = {
+          client_id: params["client_id"] || Hubspot::Config.client_id,
+          grant_type: "refresh_token",
+          client_secret: params["client_secret"] || Hubspot::Config.client_secret,
+          redirect_uri: params["redirect_uri"] || Hubspot::Config.redirect_uri,
+          refresh_token: params["refresh_token"]
+        }
+        response = post(oauth_url, body: body, headers: DEFAULT_OAUTH_HEADERS)
+        log_request_and_response oauth_url, response, body
+        raise(Hubspot::RequestError.new(response)) unless response.success?
+
+        no_parse ? response : response.parsed_response
+      end
+
+      def create(params)
+        params.stringify_keys!
+        no_parse = params.delete("no_parse") { false }
+        body = {
+          client_id: params["client_id"] || Hubspot::Config.client_id,
+          grant_type: "authorization_code",
+          client_secret: params["client_secret"] || Hubspot::Config.client_secret,
+          redirect_uri: params["redirect_uri"] || Hubspot::Config.redirect_uri,
+          code: params["code"]
+        }
+        response = post(oauth_url, body: body, headers: DEFAULT_OAUTH_HEADERS)
+        log_request_and_response oauth_url, response, body
+        raise(Hubspot::RequestError.new(response)) unless response.success?
+
+        no_parse ? response : response.parsed_response
+      end
+
+      def oauth_url
+        oauth_url = Hubspot::Config.base_url + "/oauth/v1/token"
+      end
+    end
+  end
+end


### PR DESCRIPTION
- This class is responsbile for grabbing and refreshing OAuth access tokens.
- It just returns the results to you for the caller to actually do something with them.
- It inherits from the Connection class because it needs to re-use many of the methods for consistency, yet actually has fairly different needs. The headers are form-urlencoded, not json. So using the existing post_json methods would have required some re-jiggering to work correctly here. Also, these dont' require an API key in the same way as the others, so we would have to always pass in "hapikey": false, and this would have required more changes to the post_json method. Lastly, of course you aren't actually posting json here! So using that method would be extra weird.